### PR TITLE
editorconfig default-charset

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,7 @@ root = true
 
 ; Unix-style newlines
 [*]
+charset = UTF-8
 end_of_line = LF
 indent_style = space
 indent_size = 4


### PR DESCRIPTION
Pour être sûr que les fichiers sont bien créés en UTF-8